### PR TITLE
Use root-relative paths for site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ npm run dev
 npm run build
 ```
 
-The site is configured for GitHub Pages with the `/oc-doc` base path.
+The site is configured for GitHub Pages root-relative deployment.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,5 @@ import { defineConfig } from 'astro/config';
 
 export default defineConfig({
   site: 'https://classiclobster.github.io',
-  base: '/oc-doc',
   output: 'static'
 });


### PR DESCRIPTION
## Summary
- remove the /oc-doc Astro base path
- build the site with root-relative links so the homepage is /
- update the README to match the new deployment assumption

## Validation
- ran npm run build successfully
