### PR TITLE
Remove Astro.base from layout navigation links

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -117,11 +117,11 @@ const { title = 'OpenClaw Docs' } = Astro.props;
         <aside>
           <nav>
             <ul>
-              <li><a href={`${Astro.base}/`} class={Astro.url.pathname === `${Astro.base}/` ? 'active' : ''}>Home</a></li>
-              <li><a href={`${Astro.base}/docs/how-openclaw-works`} class={Astro.url.pathname.includes('/docs/how-openclaw-works') ? 'active' : ''}>How OpenClaw Works</a></li>
-              <li><a href={`${Astro.base}/docs/architecture`} class={Astro.url.pathname.includes('/docs/architecture') ? 'active' : ''}>Architecture</a></li>
-              <li><a href={`${Astro.base}/docs/channels-sessions-memory`} class={Astro.url.pathname.includes('/docs/channels-sessions-memory') ? 'active' : ''}>Channels, Sessions, Memory</a></li>
-              <li><a href={`${Astro.base}/docs/automation`} class={Astro.url.pathname.includes('/docs/automation') ? 'active' : ''}>Automation</a></li>
+              <li><a href="/" class={Astro.url.pathname === '/' ? 'active' : ''}>Home</a></li>
+              <li><a href="/docs/how-openclaw-works" class={Astro.url.pathname.includes('/docs/how-openclaw-works') ? 'active' : ''}>How OpenClaw Works</a></li>
+              <li><a href="/docs/architecture" class={Astro.url.pathname.includes('/docs/architecture') ? 'active' : ''}>Architecture</a></li>
+              <li><a href="/docs/channels-sessions-memory" class={Astro.url.pathname.includes('/docs/channels-sessions-memory') ? 'active' : ''}>Channels, Sessions, Memory</a></li>
+              <li><a href="/docs/automation" class={Astro.url.pathname.includes('/docs/automation') ? 'active' : ''}>Automation</a></li>
             </ul>
           </nav>
         </aside>


### PR DESCRIPTION
## Summary
- remove Astro.base from DocsLayout navigation links
- use root-relative links for home and docs pages

## Validation
- ran npm run build successfully
