### PR TITLE
Add context docs nav link and flash cards

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,5 +1,5 @@
 ---
-const { title = 'OpenClaw Docs' } = Astro.props;
+const { title = 'OpenClaw Docs', flashCards = [] } = Astro.props;
 const baseUrl = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : `${import.meta.env.BASE_URL}/`;
 ---
 <!doctype html>
@@ -99,6 +99,33 @@ const baseUrl = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_UR
         margin-bottom: 24px;
       }
       :global(.muted) { color: var(--muted); }
+      :global(.flash-cards) {
+        margin-top: 3rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--border);
+      }
+      :global(.flash-card-list) {
+        display: grid;
+        gap: 14px;
+        margin: 0;
+      }
+      :global(.flash-card) {
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 16px 18px;
+        background: rgba(15, 23, 42, .65);
+      }
+      :global(.flash-card summary) {
+        cursor: pointer;
+        font-weight: 700;
+        color: var(--text);
+        list-style: none;
+      }
+      :global(.flash-card summary::-webkit-details-marker) { display: none; }
+      :global(.flash-card .answer) {
+        margin-top: 10px;
+        color: var(--muted);
+      }
       @media (max-width: 900px) {
         .layout { grid-template-columns: 1fr; }
         aside { position: static; }
@@ -122,12 +149,26 @@ const baseUrl = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_UR
               <li><a href={`${baseUrl}docs/how-openclaw-works/`} class={Astro.url.pathname.includes('/docs/how-openclaw-works') ? 'active' : ''}>How OpenClaw Works</a></li>
               <li><a href={`${baseUrl}docs/architecture/`} class={Astro.url.pathname.includes('/docs/architecture') ? 'active' : ''}>Architecture</a></li>
               <li><a href={`${baseUrl}docs/channels-sessions-memory/`} class={Astro.url.pathname.includes('/docs/channels-sessions-memory') ? 'active' : ''}>Channels, Sessions, Memory</a></li>
+              <li><a href={`${baseUrl}docs/context/`} class={Astro.url.pathname.includes('/docs/context') ? 'active' : ''}>Context</a></li>
               <li><a href={`${baseUrl}docs/automation/`} class={Astro.url.pathname.includes('/docs/automation') ? 'active' : ''}>Automation</a></li>
             </ul>
           </nav>
         </aside>
         <main>
           <slot />
+          {flashCards.length > 0 && (
+            <section class="flash-cards">
+              <h2>Flash Cards</h2>
+              <div class="flash-card-list">
+                {flashCards.map((card) => (
+                  <details class="flash-card">
+                    <summary>{card.question}</summary>
+                    <div class="answer">{card.answer}</div>
+                  </details>
+                ))}
+              </div>
+            </section>
+          )}
         </main>
       </div>
     </div>

--- a/src/pages/docs/architecture.md
+++ b/src/pages/docs/architecture.md
@@ -1,6 +1,13 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: Architecture
+flashCards:
+  - question: What are the major layers in OpenClaw architecture?
+    answer: Gateway, agents, tools, channels, and workspace plus memory.
+  - question: What does the gateway do?
+    answer: It centralizes session state, routing, auth, connected channels, and reliable agent execution.
+  - question: What is the request flow?
+    answer: Channel → Gateway → Agent session → Model plus tools → Final response → Delivery.
 ---
 
 # Architecture

--- a/src/pages/docs/automation.md
+++ b/src/pages/docs/automation.md
@@ -1,6 +1,13 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: Automation
+flashCards:
+  - question: When should you use cron jobs?
+    answer: Use cron jobs when the schedule needs to be precise, like a daily brief at a specific time.
+  - question: When are heartbeats a better fit?
+    answer: Heartbeats work better for lightweight checks that can drift a bit and only need to speak up when something matters.
+  - question: What is a simple equation for automation choice?
+    answer: Precision needed plus fixed schedule points to cron; flexible periodic checking points to heartbeat.
 ---
 
 # Automation

--- a/src/pages/docs/channels-sessions-memory.md
+++ b/src/pages/docs/channels-sessions-memory.md
@@ -1,6 +1,13 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: Channels, Sessions, and Memory
+flashCards:
+  - question: What do channels do?
+    answer: Channels are the entry and exit points for messages, like Discord, Telegram, WhatsApp, or a local UI.
+  - question: What is a session?
+    answer: A session stores continuity such as recent turns, tool traces, routing metadata, and the working context for a conversation.
+  - question: What does memory usually contain?
+    answer: File-based memory often includes daily notes, long-term memory files, and workspace documents the agent can read and update.
 ---
 
 # Channels, sessions, and memory

--- a/src/pages/docs/context.md
+++ b/src/pages/docs/context.md
@@ -1,6 +1,15 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: How Context Works
+flashCards:
+  - question: What is context in OpenClaw?
+    answer: Context is the working memory the agent sees during a run, including the current message, recent turns, instructions, files, memory, and tool output.
+  - question: What can fill up context?
+    answer: Long conversations, large tool outputs, long prompts, pasted logs, documents, and repeated memory or history injection.
+  - question: How can you calculate available room in context?
+    answer: Available room is the context window minus the tokens already used by instructions, messages, files, and tool output.
+  - question: What is a practical way to reset context?
+    answer: Start a new session, use a reset command like /new or /reset, or reduce what gets injected from memory and tools.
 ---
 
 # How context works in OpenClaw

--- a/src/pages/docs/how-openclaw-works.md
+++ b/src/pages/docs/how-openclaw-works.md
@@ -1,6 +1,13 @@
 ---
 layout: ../../layouts/DocsLayout.astro
 title: How OpenClaw Works
+flashCards:
+  - question: What is OpenClaw in one sentence?
+    answer: OpenClaw is a self-hosted AI agent system that routes messages into sessions, uses tools, and replies through different channels.
+  - question: What are the core parts of the basic loop?
+    answer: Message in, route to session, load context, let the model decide on tools or a direct reply, then deliver the result back out.
+  - question: Why does OpenClaw matter as a system?
+    answer: It provides coordination, persistence, routing, automation, and tool access instead of behaving like a one-shot chatbot.
 ---
 
 # How OpenClaw works

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,6 +14,7 @@ const baseUrl = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_UR
     <li>Core architecture concepts</li>
     <li>How channels, sessions, and memory interact</li>
     <li>How automation works with cron jobs and heartbeat checks</li>
+    <li>How context fills up and how to manage it</li>
   </ul>
 
   <h2>Why Astro</h2>


### PR DESCRIPTION
- Add the context doc to the docs navigation\n- Add a Flash Cards section to each docs page in src/pages/docs\n- Use native disclosure behavior with no JavaScript\n- Update the home page to mention context\n\nBuild verified with npm run build.